### PR TITLE
Add containerisation support

### DIFF
--- a/lobby/Dockerfile
+++ b/lobby/Dockerfile
@@ -1,0 +1,13 @@
+from silkeh/clang:18 as build
+workdir /src
+
+copy . .
+run ./build.sh
+
+from debian:stable-slim
+copy --from=build /src/aocf_server.run .
+
+expose 5001/tcp
+expose 5001/udp
+cmd ["./aocf_server.run", "5001"]
+

--- a/lobby/docker-compose.yaml
+++ b/lobby/docker-compose.yaml
@@ -1,0 +1,10 @@
+services:
+  squiroll-lobby:
+    image: squiroll-lobby
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 5001:5001
+


### PR DESCRIPTION
As the name implies, this adds docker/podman support along with compose support to the lobby bit of Squiroll. If/when #6 is merged I might make another pr to move the Dockerfile from build.sh to cmake.